### PR TITLE
Removing old diagnosis enum from passport creation, it was replaced b…

### DIFF
--- a/Get2KnowMe/client/pages/CreatePassport.jsx
+++ b/Get2KnowMe/client/pages/CreatePassport.jsx
@@ -28,7 +28,7 @@ const CreatePassport = () => {
     firstName: "",
     lastName: "",
     preferredName: "",
-    diagnoses: [], // Changed from single diagnosis to multiple diagnoses
+    diagnoses: [],
     customDiagnosis: "",
     healthAlert: [],
     communicationPreferences: [],
@@ -58,8 +58,8 @@ const CreatePassport = () => {
   // Diagnosis options
   const diagnosisOptions = [
     "ASD (Autism Spectrum Disorder)",
-    "ADHD",
-    "OCD",
+    "Attention Deficit Hyperactivity Disorder (ADHD)",
+    "Obsessive-Compulsive Disorder (OCD)",
     "Dyslexia",
     "Dyscalculia",
     "Tourette's Syndrome",

--- a/Get2KnowMe/server/src/middleware/passportValidator.js
+++ b/Get2KnowMe/server/src/middleware/passportValidator.js
@@ -3,8 +3,8 @@ import { validateInternationalPhone } from '../utils/phoneValidation.js';
 
 const diagnosisOptions = [
   "ASD (Autism Spectrum Disorder)",
-  "ADHD",
-  "OCD",
+  "Attention Deficit Hyperactivity Disorder (ADHD)",
+  "Obsessive-Compulsive Disorder (OCD)",
   "Dyslexia",
   "Dyscalculia",
   "Tourette's Syndrome",

--- a/Get2KnowMe/server/src/models/User.js
+++ b/Get2KnowMe/server/src/models/User.js
@@ -7,27 +7,12 @@ const communicationPassportSchema = new Schema({
   firstName: { type: String, trim: true },
   lastName: { type: String, trim: true },
   preferredName: { type: String, trim: true },
-  diagnosis: {
-    type: String,
-    enum: [
-      'ASD (Autism Spectrum Disorder)',
-      'ADHD',
-      'OCD',
-      'Dyslexia',
-      'Dyscalculia',
-      'Tourette\'s Syndrome',
-      'C-PTSD (Complex PTSD)',
-      'Anxiety',
-      'No Diagnosis',
-      'Other'
-    ]
-  },
   diagnoses: [{
     type: String,
     enum: [
       'ASD (Autism Spectrum Disorder)',
-      'ADHD',
-      'OCD',
+      'Attention Deficit Hyperactivity Disorder (ADHD)',
+      'Obsessive-Compulsive Disorder (OCD)',
       'Dyslexia',
       'Dyscalculia',
       'Tourette\'s Syndrome',

--- a/Get2KnowMe/server/src/routes/passport-routes.js
+++ b/Get2KnowMe/server/src/routes/passport-routes.js
@@ -119,7 +119,6 @@ router.get('/public/:passcode', async (req, res) => {
       firstName: user.communicationPassport.firstName,
       lastName: user.communicationPassport.lastName,
       preferredName: user.communicationPassport.preferredName,
-      diagnosis: user.communicationPassport.diagnosis,
       diagnoses: user.communicationPassport.diagnoses,
       customDiagnosis: user.communicationPassport.customDiagnosis,
       healthAlert: user.communicationPassport.healthAlert,

--- a/Get2KnowMe/test/passport-routes.test.js
+++ b/Get2KnowMe/test/passport-routes.test.js
@@ -59,7 +59,6 @@ describe('Passport Routes', () => {
         firstName: 'Test',
         lastName: 'User',
         preferredName: 'T',
-        diagnosis: 'ADHD',
         diagnoses: ['ADHD'],
         customDiagnosis: '',
         healthAlert: ['None'],


### PR DESCRIPTION
…y an array called diagnoses instead to allow users to select multiple diagnoses instead. Renaming ADHD and OCD to full name with the abbreviation in () instead for more detail in diagnoses selection.